### PR TITLE
Add shortcut to toggle copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 ## Preview
 
 ![Preview of how plugin works](preview.gif)
+
+## Shortcut
+
+Press `Alt+C` to enable or disable copying. A toast will indicate the current state.

--- a/script.js
+++ b/script.js
@@ -1,9 +1,11 @@
 (function () {
     "use strict";
     let ccc = {
+        copyActive: true,
         init: function () {
             this.notifactionDom();
             this.copyCode();
+            this.registerShortcut();
         },
         notifactionDom: function () {
             let div = document.createElement('div');
@@ -14,6 +16,9 @@
             let cobj = this;
             document.querySelectorAll("pre, code").forEach(codeEle => {
                 codeEle.addEventListener('dblclick', function (e) {
+                    if (!cobj.copyActive) {
+                        return;
+                    }
                     if (navigator.clipboard) {
                         navigator.clipboard.writeText(codeEle.textContent).then(
                             function(){
@@ -35,6 +40,15 @@
                 });
             });
         },
+        registerShortcut: function () {
+            let cobj = this;
+            window.addEventListener('keydown', function (e) {
+                if (e.altKey && (e.key === 'c' || e.key === 'C')) {
+                    cobj.copyActive = !cobj.copyActive;
+                    cobj.showMsg(cobj.copyActive ? 'Copying enabled' : 'Copying disabled');
+                }
+            });
+        },
         showMsg: function (message) {
             let x = document.getElementById("cccTost");
             x.className = "show";
@@ -48,3 +62,4 @@
     };
     new ClickCopy().initialize();
 })();
+


### PR DESCRIPTION
## Summary
- add `copyActive` state and register `Alt+C` listener
- show toast on shortcut to enable/disable copying
- skip copy action when disabled
- document the new shortcut usage in README

## Testing
- `node --check script.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ce86dbac8832783da8a844b004e24