### PR TITLE
Persist toggle setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@
 ## Shortcut
 
 Press `Alt+C` to enable or disable copying. A toast will indicate the current state.
+The extension remembers your choice for future pages.

--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,8 @@
       "run_at": "document_end"
     }
   ],
+  "permissions": [
+    "storage"
+  ],
   "manifest_version": 3
 }

--- a/script.js
+++ b/script.js
@@ -3,9 +3,12 @@
     let ccc = {
         copyActive: true,
         init: function () {
-            this.notifactionDom();
-            this.copyCode();
-            this.registerShortcut();
+            let cobj = this;
+            this.loadState(function () {
+                cobj.notifactionDom();
+                cobj.copyCode();
+                cobj.registerShortcut();
+            });
         },
         notifactionDom: function () {
             let div = document.createElement('div');
@@ -45,9 +48,34 @@
             window.addEventListener('keydown', function (e) {
                 if (e.altKey && (e.key === 'c' || e.key === 'C')) {
                     cobj.copyActive = !cobj.copyActive;
+                    cobj.saveState();
                     cobj.showMsg(cobj.copyActive ? 'Copying enabled' : 'Copying disabled');
                 }
             });
+        },
+        loadState: function (callback) {
+            let cobj = this;
+            if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+                chrome.storage.local.get(['copyActive'], function (result) {
+                    if (typeof result.copyActive !== 'undefined') {
+                        cobj.copyActive = result.copyActive;
+                    }
+                    callback();
+                });
+            } else {
+                let stored = localStorage.getItem('copyActive');
+                if (stored !== null) {
+                    cobj.copyActive = stored === 'true';
+                }
+                callback();
+            }
+        },
+        saveState: function () {
+            if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+                chrome.storage.local.set({ copyActive: this.copyActive });
+            } else {
+                localStorage.setItem('copyActive', this.copyActive);
+            }
         },
         showMsg: function (message) {
             let x = document.getElementById("cccTost");


### PR DESCRIPTION
## Summary
- remember whether copying is enabled or disabled
- add permissions for storage
- document that the choice persists across pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ce9e1abb483278d2081eed4ce9ce3