### PR TITLE
Add options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
       "run_at": "document_end"
     }
   ],
+  "options_page": "options.html",
   "permissions": [
     "storage"
   ],

--- a/options.html
+++ b/options.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Click Copy {Code} Options</title>
+</head>
+<body>
+    <h1>Extension Options</h1>
+    <form>
+        <label>
+            Interaction mode:
+            <select id="interactionMode">
+                <option value="double">Double click</option>
+                <option value="single">Single click</option>
+            </select>
+        </label>
+        <br/>
+        <label>
+            Theme:
+            <select id="theme">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+            </select>
+        </label>
+        <br/>
+        <button type="button" id="save">Save</button>
+        <div id="status"></div>
+    </form>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,29 @@
+// Saves options to chrome.storage
+function saveOptions() {
+  const interactionMode = document.getElementById('interactionMode').value;
+  const theme = document.getElementById('theme').value;
+
+  chrome.storage.local.set({
+    interactionMode: interactionMode,
+    theme: theme
+  }, function() {
+    const status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(() => { status.textContent = ''; }, 1000);
+  });
+}
+
+// Restores select box state using the preferences stored in chrome.storage.
+function restoreOptions() {
+  chrome.storage.local.get(['interactionMode', 'theme'], function(items) {
+    if (items.interactionMode) {
+      document.getElementById('interactionMode').value = items.interactionMode;
+    }
+    if (items.theme) {
+      document.getElementById('theme').value = items.theme;
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('save').addEventListener('click', saveOptions);


### PR DESCRIPTION
## Summary
- create `options.html` with controls for interaction mode and theme
- add `options.js` to load and save settings using `chrome.storage.local`
- register the options page in `manifest.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cec924ec083279869639ddb092dd9