### PR TITLE
Add customizable selector options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@
 
 Press `Alt+C` to enable or disable copying. A toast will indicate the current state.
 The extension remembers your choice for future pages.
+
+## Options
+
+The options page lets you define extra CSS selectors for elements that should act as code blocks. Each selector should be on its own line.

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
   "name": "Click Copy {Code}",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Kiran Shahi",
   "homepage_url": "https://github.com/kiranshahi/Click-Copy-Code",
   "description": "Software engineer's friend. Helps to copy code from any website just in double click.",
+  "options_page": "options.html",
   "icons": {
     "16": "images/curly-brackets-16.png",
     "32": "images/curly-brackets-32.png",

--- a/options.html
+++ b/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Click Copy {Code} Options</title>
+</head>
+<body>
+    <h1>Click Copy {Code} Options</h1>
+    <p>Add additional CSS selectors for elements that contain code. One selector per line.</p>
+    <textarea id="selectors" rows="6" cols="50"></textarea><br>
+    <button id="save">Save</button>
+    <span id="status"></span>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,42 @@
+(function () {
+    'use strict';
+
+    function showStatus(message) {
+        const status = document.getElementById('status');
+        status.textContent = message;
+        setTimeout(function () { status.textContent = ''; }, 1000);
+    }
+
+    function saveOptions() {
+        const selectors = document.getElementById('selectors').value
+            .split('\n')
+            .map(function (s) { return s.trim(); })
+            .filter(function (s) { return s; });
+        if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+            chrome.storage.local.set({ additionalSelectors: selectors }, function () {
+                showStatus('Options saved.');
+            });
+        } else {
+            localStorage.setItem('additionalSelectors', JSON.stringify(selectors));
+            showStatus('Options saved.');
+        }
+    }
+
+    function restoreOptions() {
+        if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+            chrome.storage.local.get(['additionalSelectors'], function (result) {
+                const selectors = result.additionalSelectors || [];
+                document.getElementById('selectors').value = selectors.join('\n');
+            });
+        } else {
+            const stored = localStorage.getItem('additionalSelectors');
+            const selectors = stored ? JSON.parse(stored) : [];
+            document.getElementById('selectors').value = selectors.join('\n');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        restoreOptions();
+        document.getElementById('save').addEventListener('click', saveOptions);
+    });
+})();

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@
     "use strict";
     let ccc = {
         copyActive: true,
+        additionalSelectors: [],
         init: function () {
             let cobj = this;
             this.loadState(function () {
@@ -17,7 +18,8 @@
         },
         copyCode: function () {
             let cobj = this;
-            document.querySelectorAll("pre, code").forEach(codeEle => {
+            let selectors = ['pre', 'code'].concat(cobj.additionalSelectors || []);
+            document.querySelectorAll(selectors.join(', ')).forEach(codeEle => {
                 codeEle.addEventListener('dblclick', function (e) {
                     if (!cobj.copyActive) {
                         return;
@@ -56,9 +58,12 @@
         loadState: function (callback) {
             let cobj = this;
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
-                chrome.storage.local.get(['copyActive'], function (result) {
+                chrome.storage.local.get(['copyActive', 'additionalSelectors'], function (result) {
                     if (typeof result.copyActive !== 'undefined') {
                         cobj.copyActive = result.copyActive;
+                    }
+                    if (Array.isArray(result.additionalSelectors)) {
+                        cobj.additionalSelectors = result.additionalSelectors;
                     }
                     callback();
                 });
@@ -66,6 +71,14 @@
                 let stored = localStorage.getItem('copyActive');
                 if (stored !== null) {
                     cobj.copyActive = stored === 'true';
+                }
+                let selStored = localStorage.getItem('additionalSelectors');
+                if (selStored) {
+                    try {
+                        cobj.additionalSelectors = JSON.parse(selStored);
+                    } catch (e) {
+                        cobj.additionalSelectors = [];
+                    }
                 }
                 callback();
             }


### PR DESCRIPTION
## Summary
- add options page to configure extra CSS selectors
- persist selectors in storage and load them in the content script
- extend copy handler to query stored selectors
- document new options feature
- bump version to 0.0.2

## Testing
- `node --check script.js`
- `node --check options.js`


------
https://chatgpt.com/codex/tasks/task_e_688cec96286c8327bcc8630159033f05