### PR TITLE
Add dark mode detection and theme-aware toast

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,17 +2,27 @@
     "use strict";
     let ccc = {
         copyActive: true,
+        theme: 'light',
         init: function () {
             let cobj = this;
             this.loadState(function () {
+                cobj.applyTheme();
                 cobj.notifactionDom();
                 cobj.copyCode();
                 cobj.registerShortcut();
             });
         },
+        applyTheme: function () {
+            this.theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            document.documentElement.setAttribute('data-theme', this.theme);
+        },
         notifactionDom: function () {
             let div = document.createElement('div');
             div.setAttribute("id", "cccTost");
+            if (this.theme === 'dark') {
+                div.style.backgroundColor = '#333333';
+                div.style.color = '#f5f5f5';
+            }
             document.body.appendChild(div);
         },
         copyCode: function () {

--- a/style.css
+++ b/style.css
@@ -1,8 +1,19 @@
+/* Theme specific variables for toast colors */
+:root {
+    --ccc-toast-bg: #6002ee;
+    --ccc-toast-color: #f5f5f5;
+}
+
+[data-theme="dark"] {
+    --ccc-toast-bg: #333333;
+    --ccc-toast-color: #f5f5f5;
+}
+
 #cccTost {
     visibility: hidden;
     min-width: 250px;
-    background-color: #6002ee;
-    color: #f5f5f5;
+    background-color: var(--ccc-toast-bg);
+    color: var(--ccc-toast-color);
     text-align: center;
     border-radius: 2px;
     padding: 16px;


### PR DESCRIPTION
## Summary
- detect the user's `prefers-color-scheme` setting
- apply a `data-theme` attribute and update toast colors

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cec9941b48327a6fd4df1ef25ad64