### PR TITLE
Add copy count metrics and options page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@
 
 Press `Alt+C` to enable or disable copying. A toast will indicate the current state.
 The extension remembers your choice for future pages.
+
+## Options
+
+The options page lets you opt-in to anonymous copy count collection. When enabled,
+the extension stores how many snippets you copy each day and shows today's and
+the last week's totals. You can export the data as JSON or reset the counts from
+that page.

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
       "run_at": "document_end"
     }
   ],
+  "options_page": "options.html",
   "permissions": [
     "storage"
   ],

--- a/options.html
+++ b/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Click Copy {Code} Options</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        label { display: block; margin-bottom: 10px; }
+        #stats { margin-top: 20px; }
+        button { margin-right: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Click Copy {Code} Options</h1>
+    <label>
+        <input type="checkbox" id="collectToggle"> Enable anonymous copy count collection
+    </label>
+    <div id="stats">
+        <div>Today: <span id="todayCount">0</span></div>
+        <div>Last 7 Days: <span id="weekCount">0</span></div>
+    </div>
+    <button id="exportBtn">Export</button>
+    <button id="resetBtn">Reset</button>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,67 @@
+(function() {
+    function getStorage(keys, cb) {
+        if (chrome && chrome.storage && chrome.storage.local) {
+            chrome.storage.local.get(keys, cb);
+        } else {
+            let result = {};
+            keys.forEach(function(k){
+                let v = localStorage.getItem(k);
+                if (v !== null) {
+                    result[k] = k === 'copyCounts' ? JSON.parse(v) : (v === 'true' ? true : v);
+                }
+            });
+            cb(result);
+        }
+    }
+    function setStorage(obj, cb) {
+        if (chrome && chrome.storage && chrome.storage.local) {
+            chrome.storage.local.set(obj, cb);
+        } else {
+            Object.keys(obj).forEach(function(k){
+                let v = obj[k];
+                if (k === 'copyCounts') {
+                    localStorage.setItem(k, JSON.stringify(v));
+                } else {
+                    localStorage.setItem(k, v);
+                }
+            });
+            if (cb) cb();
+        }
+    }
+
+    function updateStats(counts) {
+        const today = new Date().toISOString().slice(0,10);
+        const todayCount = counts[today] || 0;
+        let weekCount = 0;
+        for (let i=0;i<7;i++) {
+            const d = new Date(Date.now() - i*24*60*60*1000).toISOString().slice(0,10);
+            weekCount += counts[d] || 0;
+        }
+        document.getElementById('todayCount').textContent = todayCount;
+        document.getElementById('weekCount').textContent = weekCount;
+    }
+
+    function init() {
+        getStorage(['collectCounts', 'copyCounts'], function(result){
+            document.getElementById('collectToggle').checked = !!result.collectCounts;
+            const counts = result.copyCounts || {};
+            updateStats(counts);
+            document.getElementById('collectToggle').addEventListener('change', function(){
+                setStorage({collectCounts: this.checked});
+            });
+            document.getElementById('exportBtn').addEventListener('click', function(){
+                const blob = new Blob([JSON.stringify(counts, null, 2)], {type: 'application/json'});
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'copy_counts.json';
+                a.click();
+                URL.revokeObjectURL(url);
+            });
+            document.getElementById('resetBtn').addEventListener('click', function(){
+                setStorage({copyCounts: {}}, function(){ location.reload(); });
+            });
+        });
+    }
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@
     "use strict";
     let ccc = {
         copyActive: true,
+        collectCounts: false,
+        copyCounts: {},
         init: function () {
             let cobj = this;
             this.loadState(function () {
@@ -25,7 +27,8 @@
                     if (navigator.clipboard) {
                         navigator.clipboard.writeText(codeEle.textContent).then(
                             function(){
-                                cobj.showMsg("Code snippet copied successfully !") // success 
+                                cobj.showMsg("Code snippet copied successfully !") // success
+                                cobj.incrementCopyCount();
                             })
                           .catch(
                              function() {
@@ -37,7 +40,12 @@
                         range.selectNode(this);
                         window.getSelection().removeAllRanges();
                         window.getSelection().addRange(range);
-                        document.execCommand("copy") ? cobj.showMsg("Code snippet copied successfully !") : cobj.showMsg("Opps!! some error occured while copying code snippet.");
+                        if (document.execCommand("copy")) {
+                            cobj.showMsg("Code snippet copied successfully !");
+                            cobj.incrementCopyCount();
+                        } else {
+                            cobj.showMsg("Opps!! some error occured while copying code snippet.");
+                        }
                         window.getSelection().empty();
                     }
                 });
@@ -56,9 +64,15 @@
         loadState: function (callback) {
             let cobj = this;
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
-                chrome.storage.local.get(['copyActive'], function (result) {
+                chrome.storage.local.get(['copyActive', 'collectCounts', 'copyCounts'], function (result) {
                     if (typeof result.copyActive !== 'undefined') {
                         cobj.copyActive = result.copyActive;
+                    }
+                    if (typeof result.collectCounts !== 'undefined') {
+                        cobj.collectCounts = result.collectCounts;
+                    }
+                    if (result.copyCounts) {
+                        cobj.copyCounts = result.copyCounts;
                     }
                     callback();
                 });
@@ -67,14 +81,25 @@
                 if (stored !== null) {
                     cobj.copyActive = stored === 'true';
                 }
+                let cc = localStorage.getItem('collectCounts');
+                if (cc !== null) {
+                    cobj.collectCounts = cc === 'true';
+                }
+                let counts = localStorage.getItem('copyCounts');
+                if (counts) {
+                    try {
+                        cobj.copyCounts = JSON.parse(counts);
+                    } catch (e) {}
+                }
                 callback();
             }
         },
         saveState: function () {
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
-                chrome.storage.local.set({ copyActive: this.copyActive });
+                chrome.storage.local.set({ copyActive: this.copyActive, collectCounts: this.collectCounts });
             } else {
                 localStorage.setItem('copyActive', this.copyActive);
+                localStorage.setItem('collectCounts', this.collectCounts);
             }
         },
         showMsg: function (message) {
@@ -82,6 +107,18 @@
             x.className = "show";
             x.textContent = message;
             setTimeout(function () { x.className = x.className.replace("show", ""); }, 3000);
+        },
+        incrementCopyCount: function () {
+            if (!this.collectCounts) {
+                return;
+            }
+            let today = new Date().toISOString().slice(0, 10);
+            this.copyCounts[today] = (this.copyCounts[today] || 0) + 1;
+            if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+                chrome.storage.local.set({ copyCounts: this.copyCounts });
+            } else {
+                localStorage.setItem('copyCounts', JSON.stringify(this.copyCounts));
+            }
         }
     };
     function ClickCopy() { }


### PR DESCRIPTION
## Summary
- track anonymous copy counts and persist to storage
- add options page with toggle, stats display and export/reset buttons
- wire options page into manifest
- document new feature in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688cec9ec13c83279c647b21d13a98af