### PR TITLE
Add theme customization

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,9 @@
   "permissions": [
     "storage"
   ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "manifest_version": 3
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Click Copy Options</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        #customColors { margin-top: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Notification Theme</h1>
+    <label><input type="radio" name="scheme" value="light"> Light</label><br>
+    <label><input type="radio" name="scheme" value="dark"> Dark</label><br>
+    <label><input type="radio" name="scheme" value="custom"> Custom</label>
+    <div id="customColors" style="display:none;">
+        <label>Background: <input type="color" id="bgColor" value="#6002ee"></label>
+        <label>Text: <input type="color" id="textColor" value="#f5f5f5"></label>
+    </div>
+    <div style="margin-top:10px;">
+        <button id="save">Save</button>
+    </div>
+    <div id="status" style="margin-top:10px;color:green;"></div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const schemeRadios = document.querySelectorAll('input[name="scheme"]');
+            const customColors = document.getElementById('customColors');
+            const bgColor = document.getElementById('bgColor');
+            const textColor = document.getElementById('textColor');
+            const status = document.getElementById('status');
+
+            function load() {
+                const fallback = {scheme: 'light', bgColor: '#6002ee', textColor: '#f5f5f5'};
+                if (chrome.storage && chrome.storage.local) {
+                    chrome.storage.local.get(['theme'], function (res) {
+                        const theme = res.theme || fallback;
+                        setValues(theme);
+                    });
+                } else {
+                    const theme = JSON.parse(localStorage.getItem('theme')) || fallback;
+                    setValues(theme);
+                }
+            }
+
+            function setValues(theme) {
+                document.querySelector(`input[value="${theme.scheme}"]`).checked = true;
+                if (theme.scheme === 'custom') {
+                    customColors.style.display = 'block';
+                    bgColor.value = theme.bgColor || '#6002ee';
+                    textColor.value = theme.textColor || '#f5f5f5';
+                }
+            }
+
+            schemeRadios.forEach(r => {
+                r.addEventListener('change', function () {
+                    customColors.style.display = this.value === 'custom' ? 'block' : 'none';
+                });
+            });
+
+            document.getElementById('save').addEventListener('click', function () {
+                const scheme = document.querySelector('input[name="scheme"]:checked').value;
+                const theme = {scheme};
+                if (scheme === 'custom') {
+                    theme.bgColor = bgColor.value;
+                    theme.textColor = textColor.value;
+                }
+                if (chrome.storage && chrome.storage.local) {
+                    chrome.storage.local.set({theme}, function () {
+                        status.textContent = 'Saved!';
+                        setTimeout(()=>status.textContent='', 1000);
+                    });
+                } else {
+                    localStorage.setItem('theme', JSON.stringify(theme));
+                    status.textContent = 'Saved!';
+                    setTimeout(()=>status.textContent='', 1000);
+                }
+            });
+
+            load();
+        });
+    </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@
     "use strict";
     let ccc = {
         copyActive: true,
+        theme: { scheme: 'light', bgColor: '#6002ee', textColor: '#f5f5f5' },
         init: function () {
             let cobj = this;
             this.loadState(function () {
@@ -13,6 +14,14 @@
         notifactionDom: function () {
             let div = document.createElement('div');
             div.setAttribute("id", "cccTost");
+            if (this.theme.scheme === 'light') {
+                div.classList.add('light');
+            } else if (this.theme.scheme === 'dark') {
+                div.classList.add('dark');
+            } else if (this.theme.scheme === 'custom') {
+                div.style.backgroundColor = this.theme.bgColor;
+                div.style.color = this.theme.textColor;
+            }
             document.body.appendChild(div);
         },
         copyCode: function () {
@@ -56,9 +65,12 @@
         loadState: function (callback) {
             let cobj = this;
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
-                chrome.storage.local.get(['copyActive'], function (result) {
+                chrome.storage.local.get(['copyActive', 'theme'], function (result) {
                     if (typeof result.copyActive !== 'undefined') {
                         cobj.copyActive = result.copyActive;
+                    }
+                    if (result.theme) {
+                        cobj.theme = result.theme;
                     }
                     callback();
                 });
@@ -66,6 +78,10 @@
                 let stored = localStorage.getItem('copyActive');
                 if (stored !== null) {
                     cobj.copyActive = stored === 'true';
+                }
+                let themeStored = localStorage.getItem('theme');
+                if (themeStored) {
+                    try { cobj.theme = JSON.parse(themeStored); } catch(e) {}
                 }
                 callback();
             }
@@ -79,9 +95,9 @@
         },
         showMsg: function (message) {
             let x = document.getElementById("cccTost");
-            x.className = "show";
+            x.classList.add("show");
             x.textContent = message;
-            setTimeout(function () { x.className = x.className.replace("show", ""); }, 3000);
+            setTimeout(function () { x.classList.remove("show"); }, 3000);
         }
     };
     function ClickCopy() { }

--- a/style.css
+++ b/style.css
@@ -65,3 +65,14 @@
         opacity: 0;
     }
 }
+
+#cccTost.light {
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+#cccTost.dark {
+    background-color: #333;
+    color: #f5f5f5;
+}
+


### PR DESCRIPTION
## Summary
- create options page for theme selection
- store theme choice in extension storage
- apply theme styles in toast notification
- expose options page via manifest
- support light and dark styles in CSS

## Testing
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_688cec92024483279caa5a5bfebea3dd