### PR TITLE
Add customizable notification theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ You can choose how code is copied from the extension options page. Available opt
 * **dblclick** – copy when you double click a code block (default)
 * **hover** – copy when you hover over a code block
 * **both** – allow both interactions
+
+## Notification Theme
+
+The extension shows a toast when you copy code or toggle the shortcut. You can customize the toast colors from the options page.
+
+* **light** – light background with dark text
+* **dark** – purple background with light text (default)
+* **custom** – choose your own background and text colors

--- a/options.html
+++ b/options.html
@@ -3,16 +3,35 @@
 <head>
     <meta charset="UTF-8">
     <title>Click Copy {Code} Options</title>
+    <style>
+        #customColors { margin-top: 10px; display: none; }
+        #status { margin-top: 10px; color: green; }
+    </style>
 </head>
 <body>
     <h1>Settings</h1>
-    <label for="interactionMode">Interaction Mode:</label>
-    <select id="interactionMode">
-        <option value="dblclick">Double click</option>
-        <option value="hover">Hover</option>
-        <option value="both">Both</option>
-    </select>
-    <button id="save">Save</button>
+    <div>
+        <label for="interactionMode">Interaction Mode:</label>
+        <select id="interactionMode">
+            <option value="dblclick">Double click</option>
+            <option value="hover">Hover</option>
+            <option value="both">Both</option>
+        </select>
+    </div>
+
+    <h2>Notification Theme</h2>
+    <label><input type="radio" name="scheme" value="light"> Light</label><br>
+    <label><input type="radio" name="scheme" value="dark"> Dark</label><br>
+    <label><input type="radio" name="scheme" value="custom"> Custom</label>
+    <div id="customColors">
+        <label>Background: <input type="color" id="bgColor" value="#6002ee"></label>
+        <label>Text: <input type="color" id="textColor" value="#f5f5f5"></label>
+    </div>
+
+    <div style="margin-top:10px;">
+        <button id="save">Save</button>
+    </div>
+    <div id="status"></div>
     <script src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -1,30 +1,70 @@
 (function(){
     const modeSelect = document.getElementById('interactionMode');
     const saveBtn = document.getElementById('save');
+    const schemeRadios = document.querySelectorAll('input[name="scheme"]');
+    const customColors = document.getElementById('customColors');
+    const bgColor = document.getElementById('bgColor');
+    const textColor = document.getElementById('textColor');
+    const status = document.getElementById('status');
+
+    function setThemeValues(theme){
+        const radio = document.querySelector(`input[name="scheme"][value="${theme.scheme}"]`);
+        if(radio){
+            radio.checked = true;
+        }
+        if(theme.scheme === 'custom'){
+            customColors.style.display = 'block';
+            if(theme.bgColor){ bgColor.value = theme.bgColor; }
+            if(theme.textColor){ textColor.value = theme.textColor; }
+        }else{
+            customColors.style.display = 'none';
+        }
+    }
 
     function load(){
+        const fallbackTheme = {scheme: 'dark', bgColor: '#6002ee', textColor: '#f5f5f5'};
         if(chrome.storage && chrome.storage.local){
-            chrome.storage.local.get(['interactionMode'], function(res){
+            chrome.storage.local.get(['interactionMode', 'theme'], function(res){
                 if(res.interactionMode){
                     modeSelect.value = res.interactionMode;
                 }
+                setThemeValues(res.theme || fallbackTheme);
             });
         } else {
             const val = localStorage.getItem('interactionMode');
             if(val){
                 modeSelect.value = val;
             }
+            const themeStr = localStorage.getItem('theme');
+            const theme = themeStr ? JSON.parse(themeStr) : fallbackTheme;
+            setThemeValues(theme);
         }
     }
 
     function save(){
         const mode = modeSelect.value;
+        const scheme = document.querySelector('input[name="scheme"]:checked').value;
+        const theme = {scheme};
+        if(scheme === 'custom'){
+            theme.bgColor = bgColor.value;
+            theme.textColor = textColor.value;
+        }
         if(chrome.storage && chrome.storage.local){
-            chrome.storage.local.set({interactionMode: mode});
+            chrome.storage.local.set({interactionMode: mode, theme}, function(){
+                status.textContent = 'Saved!';
+                setTimeout(()=> status.textContent='', 1000);
+            });
         } else {
             localStorage.setItem('interactionMode', mode);
+            localStorage.setItem('theme', JSON.stringify(theme));
+            status.textContent = 'Saved!';
+            setTimeout(()=> status.textContent='', 1000);
         }
     }
+
+    schemeRadios.forEach(r => r.addEventListener('change', function(){
+        customColors.style.display = this.value === 'custom' ? 'block' : 'none';
+    }));
 
     saveBtn.addEventListener('click', save);
     document.addEventListener('DOMContentLoaded', load);

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@
     let ccc = {
         copyActive: true,
         interactionMode: 'dblclick',
+        theme: {scheme: 'dark', bgColor: '#6002ee', textColor: '#f5f5f5'},
         init: function () {
             let cobj = this;
             this.loadState(function () {
@@ -15,6 +16,7 @@
             let div = document.createElement('div');
             div.setAttribute("id", "cccTost");
             document.body.appendChild(div);
+            this.applyTheme();
         },
         copyCode: function () {
             let cobj = this;
@@ -64,12 +66,15 @@
         loadState: function (callback) {
             let cobj = this;
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
-                chrome.storage.local.get(['copyActive', 'interactionMode'], function (result) {
+                chrome.storage.local.get(['copyActive', 'interactionMode', 'theme'], function (result) {
                     if (typeof result.copyActive !== 'undefined') {
                         cobj.copyActive = result.copyActive;
                     }
                     if (result.interactionMode) {
                         cobj.interactionMode = result.interactionMode;
+                    }
+                    if (result.theme) {
+                        cobj.theme = result.theme;
                     }
                     callback();
                 });
@@ -82,19 +87,40 @@
                 if (mode) {
                     cobj.interactionMode = mode;
                 }
+                let themeStr = localStorage.getItem('theme');
+                if (themeStr) {
+                    try { cobj.theme = JSON.parse(themeStr); } catch(e) {}
+                }
                 callback();
             }
         },
         saveState: function () {
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
-                chrome.storage.local.set({ copyActive: this.copyActive, interactionMode: this.interactionMode });
+                chrome.storage.local.set({ copyActive: this.copyActive, interactionMode: this.interactionMode, theme: this.theme });
             } else {
                 localStorage.setItem('copyActive', this.copyActive);
                 localStorage.setItem('interactionMode', this.interactionMode);
+                localStorage.setItem('theme', JSON.stringify(this.theme));
+            }
+        },
+        applyTheme: function(){
+            const x = document.getElementById('cccTost');
+            if(!x) return;
+            const t = this.theme || {};
+            if(t.scheme === 'light'){
+                x.style.backgroundColor = '#f5f5f5';
+                x.style.color = '#000';
+            } else if(t.scheme === 'custom'){
+                x.style.backgroundColor = t.bgColor || '#6002ee';
+                x.style.color = t.textColor || '#f5f5f5';
+            } else {
+                x.style.backgroundColor = '#6002ee';
+                x.style.color = '#f5f5f5';
             }
         },
         showMsg: function (message) {
             let x = document.getElementById("cccTost");
+            this.applyTheme();
             x.className = "show";
             x.textContent = message;
             setTimeout(function () { x.className = x.className.replace("show", ""); }, 3000);


### PR DESCRIPTION
## Summary
- allow choosing a notification color scheme
- store theme settings along with interaction mode
- apply user-selected colors to toast messages
- document new notification theme options

## Testing
- `node --check options.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688d2252de0c83278ebcb9cdd34399e9