### PR TITLE
Fix toast element typo

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@
         },
         notificationDom: function () {
             let div = document.createElement('div');
-            div.setAttribute("id", "cccTost");
+            div.setAttribute("id", "cccToast");
             document.body.appendChild(div);
             this.applyTheme();
         },
@@ -104,7 +104,7 @@
             }
         },
         applyTheme: function(){
-            const x = document.getElementById('cccTost');
+            const x = document.getElementById('cccToast');
             if(!x) return;
             const t = this.theme || {};
             if(t.scheme === 'light'){
@@ -119,7 +119,7 @@
             }
         },
         showMsg: function (message) {
-            let x = document.getElementById("cccTost");
+            let x = document.getElementById("cccToast");
             this.applyTheme();
             x.className = "show";
             x.textContent = message;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-#cccTost {
+#cccToast {
     visibility: hidden;
     min-width: 250px;
     background-color: #6002ee;
@@ -12,7 +12,7 @@
     top: 30px;
 }
 
-    #cccTost.show {
+    #cccToast.show {
         visibility: visible;
         -webkit-animation: fadein 0.5s, fadeout 0.5s 2.5s;
         animation: fadein 0.5s, fadeout 0.5s 2.5s;


### PR DESCRIPTION
## Summary
- correct the `cccTost` typo to `cccToast` in styles and JavaScript

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688d2561d560832783631f1e4f2fb32c