### PR TITLE
Update extension to options_ui

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,10 @@
       "run_at": "document_end"
     }
   ],
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
## Summary
- replace deprecated `options_page` key with `options_ui`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d260092f0832798845752d3d04032