### PR TITLE
Remove duplicate load call in options

### DIFF
--- a/options.js
+++ b/options.js
@@ -68,5 +68,4 @@
 
     saveBtn.addEventListener('click', save);
     document.addEventListener('DOMContentLoaded', load);
-    load();
 })();


### PR DESCRIPTION
## Summary
- avoid calling `load()` twice in `options.js`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d329169588327a12b6d659b141aa2