### PR TITLE
Fix typo in copy error message

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,7 +39,7 @@
                             })
                           .catch(
                              function() {
-                                cobj.showMsg("Opps!! some error occured while copying code snippet."); // error
+                                cobj.showMsg("Oops!! some error occurred while copying code snippet."); // error
                           });
                     } else {
                         let range = document.createRange();
@@ -47,7 +47,7 @@
                         range.selectNode(this);
                         window.getSelection().removeAllRanges();
                         window.getSelection().addRange(range);
-                        document.execCommand("copy") ? cobj.showMsg("Code snippet copied successfully !") : cobj.showMsg("Opps!! some error occured while copying code snippet.");
+                        document.execCommand("copy") ? cobj.showMsg("Code snippet copied successfully !") : cobj.showMsg("Oops!! some error occurred while copying code snippet.");
                         window.getSelection().empty();
                     }
                 }));


### PR DESCRIPTION
## Summary
- correct spelling in error toast messages

## Testing
- `grep -n 'Oops!!' script.js`

------
https://chatgpt.com/codex/tasks/task_e_688d332f1234832789679e085b44f01c