### PR TITLE
Add chrome existence check in options.js

### DIFF
--- a/options.js
+++ b/options.js
@@ -23,7 +23,7 @@
 
     function load(){
         const fallbackTheme = {scheme: 'dark', bgColor: '#6002ee', textColor: '#f5f5f5'};
-        if(chrome.storage && chrome.storage.local){
+        if(typeof chrome !== "undefined" && chrome.storage && chrome.storage.local){
             chrome.storage.local.get(['interactionMode', 'theme'], function(res){
                 if(res.interactionMode){
                     modeSelect.value = res.interactionMode;
@@ -49,7 +49,7 @@
             theme.bgColor = bgColor.value;
             theme.textColor = textColor.value;
         }
-        if(chrome.storage && chrome.storage.local){
+        if(typeof chrome !== "undefined" && chrome.storage && chrome.storage.local){
             chrome.storage.local.set({interactionMode: mode, theme}, function(){
                 status.textContent = 'Saved!';
                 setTimeout(()=> status.textContent='', 1000);


### PR DESCRIPTION
## Summary
- avoid errors when options page is opened outside extension context
- use `typeof chrome !== 'undefined'` before using `chrome.storage`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d36ceb76c832789728e7904c69014