### PR TITLE
feat: add hover copy button

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,6 +30,22 @@
     }
 }
 
+.ccc-copy-btn {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    display: none;
+    font-size: 12px;
+    padding: 2px 6px;
+    cursor: pointer;
+    z-index: 1000;
+}
+
+pre:hover .ccc-copy-btn,
+code:hover .ccc-copy-btn {
+    display: block;
+}
+
 @keyframes fadein {
     from {
         right: 0;


### PR DESCRIPTION
## Summary
- replace automatic hover copying with a hover-triggered copy button
- style the copy button to appear over code blocks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e827df6908327a26064f123dce3ec