### PR TITLE
Add toast theme preview and live color updates

### DIFF
--- a/options.html
+++ b/options.html
@@ -6,6 +6,7 @@
     <style>
         #customColors { margin-top: 10px; display: none; }
         #status { margin-top: 10px; color: green; }
+        #toastPreview { margin-top: 10px; padding: 10px; border-radius: 2px; display: inline-block; background-color: #6002ee; color: #f5f5f5; min-width: 120px; text-align: center; }
     </style>
 </head>
 <body>
@@ -27,6 +28,7 @@
         <label>Background: <input type="color" id="bgColor" value="#6002ee"></label>
         <label>Text: <input type="color" id="textColor" value="#f5f5f5"></label>
     </div>
+    <div id="toastPreview">Copied!</div>
 
     <div style="margin-top:10px;">
         <button id="save">Save</button>

--- a/options.js
+++ b/options.js
@@ -7,9 +7,24 @@
     const bgColor = document.getElementById('bgColor');
     const textColor = document.getElementById('textColor');
     const status = document.getElementById('status');
+    const toastPreview = document.getElementById('toastPreview');
 
     const defaultMode = 'dblclick';
     const defaultTheme = {scheme: 'dark', bgColor: '#6002ee', textColor: '#f5f5f5'};
+
+    function applyPreview(theme){
+        if(!toastPreview) return;
+        if(theme.scheme === 'light'){
+            toastPreview.style.backgroundColor = '#f5f5f5';
+            toastPreview.style.color = '#000';
+        } else if(theme.scheme === 'custom'){
+            toastPreview.style.backgroundColor = theme.bgColor || '#6002ee';
+            toastPreview.style.color = theme.textColor || '#f5f5f5';
+        } else {
+            toastPreview.style.backgroundColor = '#6002ee';
+            toastPreview.style.color = '#f5f5f5';
+        }
+    }
 
     function setThemeValues(theme){
         const radio = document.querySelector(`input[name="scheme"][value="${theme.scheme}"]`);
@@ -23,6 +38,7 @@
         }else{
             customColors.style.display = 'none';
         }
+        applyPreview(theme);
     }
 
     function load(){
@@ -77,9 +93,22 @@
         }
     }
 
+    function updatePreview(){
+        const scheme = document.querySelector('input[name="scheme"]:checked').value;
+        const theme = {scheme};
+        if(scheme === 'custom'){
+            theme.bgColor = bgColor.value;
+            theme.textColor = textColor.value;
+        }
+        applyPreview(theme);
+    }
+
     schemeRadios.forEach(r => r.addEventListener('change', function(){
         customColors.style.display = this.value === 'custom' ? 'block' : 'none';
+        updatePreview();
     }));
+    bgColor.addEventListener('input', updatePreview);
+    textColor.addEventListener('input', updatePreview);
 
     saveBtn.addEventListener('click', save);
     resetBtn.addEventListener('click', resetOptions);


### PR DESCRIPTION
## Summary
- show a mini toast preview in options
- update preview colors when changing theme or custom colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e84fd18008327ad4929f394fabbef