### PR TITLE
Wrap options in form with fieldsets and flex layout

### DIFF
--- a/options.html
+++ b/options.html
@@ -4,36 +4,50 @@
     <meta charset="UTF-8">
     <title>Click Copy {Code} Options</title>
     <style>
-        #customColors { margin-top: 10px; display: none; }
+        form { display: flex; flex-direction: column; gap: 20px; }
+        fieldset { padding: 10px; }
+        .interaction-mode { display: flex; align-items: center; gap: 10px; }
+        .theme-options { display: flex; flex-direction: column; gap: 5px; }
+        .theme-options label { display: flex; align-items: center; gap: 5px; }
+        #customColors { margin-top: 10px; display: none; gap: 10px; }
+        #customColors label { display: flex; align-items: center; gap: 5px; }
         #status { margin-top: 10px; color: green; }
         #toastPreview { margin-top: 10px; padding: 10px; border-radius: 2px; display: inline-block; background-color: #6002ee; color: #f5f5f5; min-width: 120px; text-align: center; }
+        .buttons { display: flex; gap: 10px; margin-top: 10px; }
     </style>
 </head>
 <body>
     <h1>Settings</h1>
-    <div>
-        <label for="interactionMode">Interaction Mode:</label>
-        <select id="interactionMode">
-            <option value="dblclick">Double click</option>
-            <option value="hover">Hover</option>
-            <option value="both">Both</option>
-        </select>
-    </div>
-
-    <h2>Notification Theme</h2>
-    <label><input type="radio" name="scheme" value="light"> Light</label><br>
-    <label><input type="radio" name="scheme" value="dark"> Dark</label><br>
-    <label><input type="radio" name="scheme" value="custom"> Custom</label>
-    <div id="customColors">
-        <label>Background: <input type="color" id="bgColor" value="#6002ee"></label>
-        <label>Text: <input type="color" id="textColor" value="#f5f5f5"></label>
-    </div>
-    <div id="toastPreview">Copied!</div>
-
-    <div style="margin-top:10px;">
-        <button id="save">Save</button>
-        <button id="reset">Reset</button>
-    </div>
+    <form id="settingsForm">
+        <fieldset>
+            <legend>Interaction Mode</legend>
+            <div class="interaction-mode">
+                <label for="interactionMode">Mode:</label>
+                <select id="interactionMode">
+                    <option value="dblclick">Double click</option>
+                    <option value="hover">Hover</option>
+                    <option value="both">Both</option>
+                </select>
+            </div>
+        </fieldset>
+        <fieldset>
+            <legend>Notification Theme</legend>
+            <div class="theme-options">
+                <label><input type="radio" name="scheme" value="light"> Light</label>
+                <label><input type="radio" name="scheme" value="dark"> Dark</label>
+                <label><input type="radio" name="scheme" value="custom"> Custom</label>
+            </div>
+            <div id="customColors">
+                <label>Background: <input type="color" id="bgColor" value="#6002ee"></label>
+                <label>Text: <input type="color" id="textColor" value="#f5f5f5"></label>
+            </div>
+            <div id="toastPreview">Copied!</div>
+        </fieldset>
+        <div class="buttons">
+            <button id="save" type="button">Save</button>
+            <button id="reset" type="button">Reset</button>
+        </div>
+    </form>
     <div id="status"></div>
     <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -32,7 +32,7 @@
             radio.checked = true;
         }
         if(theme.scheme === 'custom'){
-            customColors.style.display = 'block';
+            customColors.style.display = 'flex';
             if(theme.bgColor){ bgColor.value = theme.bgColor; }
             if(theme.textColor){ textColor.value = theme.textColor; }
         }else{
@@ -104,7 +104,7 @@
     }
 
     schemeRadios.forEach(r => r.addEventListener('change', function(){
-        customColors.style.display = this.value === 'custom' ? 'block' : 'none';
+        customColors.style.display = this.value === 'custom' ? 'flex' : 'none';
         updatePreview();
     }));
     bgColor.addEventListener('input', updatePreview);


### PR DESCRIPTION
## Summary
- group interaction mode and notification theme in fieldsets inside a form
- replace `<br>` spacing with flexbox layout for labels and inputs
- update script to display custom color controls using flex

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688e85a458748327bf76c51eb93c0c5d