### PR TITLE
feat: extract options styles to external file

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,0 +1,75 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 20px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+fieldset {
+    padding: 10px;
+}
+
+.interaction-mode {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.theme-options {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.theme-options label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+#customColors {
+    margin-top: 10px;
+    display: none;
+    gap: 10px;
+}
+
+#customColors label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+#status {
+    margin-top: 10px;
+    color: green;
+}
+
+#toastPreview {
+    margin-top: 10px;
+    padding: 10px;
+    border-radius: 2px;
+    display: inline-block;
+    background-color: #6002ee;
+    color: #f5f5f5;
+    min-width: 120px;
+    text-align: center;
+}
+
+.buttons {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    background-color: #6002ee;
+    color: #f5f5f5;
+    cursor: pointer;
+}

--- a/options.html
+++ b/options.html
@@ -3,18 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Click Copy {Code} Options</title>
-    <style>
-        form { display: flex; flex-direction: column; gap: 20px; }
-        fieldset { padding: 10px; }
-        .interaction-mode { display: flex; align-items: center; gap: 10px; }
-        .theme-options { display: flex; flex-direction: column; gap: 5px; }
-        .theme-options label { display: flex; align-items: center; gap: 5px; }
-        #customColors { margin-top: 10px; display: none; gap: 10px; }
-        #customColors label { display: flex; align-items: center; gap: 5px; }
-        #status { margin-top: 10px; color: green; }
-        #toastPreview { margin-top: 10px; padding: 10px; border-radius: 2px; display: inline-block; background-color: #6002ee; color: #f5f5f5; min-width: 120px; text-align: center; }
-        .buttons { display: flex; gap: 10px; margin-top: 10px; }
-    </style>
+    <link rel="stylesheet" href="options.css">
 </head>
 <body>
     <h1>Settings</h1>


### PR DESCRIPTION
## Summary
- move inline option styles into dedicated options.css
- apply base font, spacing, and button styling
- link options.html to the new stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e86d3e6ac83279b97b4ddec4834af