### PR TITLE
Add service worker background script for MV3

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,33 +1,13 @@
-(function () {
-    "use strict";
-    let bw = {
-        init: function () {
-            this.contextMenuInit();
-        },
-        contextMenuInit: function () {
-            
-            chrome.runtime.onInstalled.addListener(async (details) => {
-                await chrome.contextMenus.create({
-                    id: 'ccc-copyCode',
-                    title: 'Copy Code',
-                    type: 'normal',
-                    contexts: ['all'],
-                });
-            });
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "ccc-copyCode",
+    title: "Copy Code",
+    contexts: ["all"],
+  });
+});
 
-            chrome.contextMenus.onClicked.addListener((info, tab) => {
-                console.log(info);
-                switch (info.menuItemId) {
-                    case 'ccc-copyCode':
-                        console.log('ccc-copyCode is clicked');
-                        break;
-                }
-            });
-        },
-    };
-    function BGWorker() { }
-    BGWorker.prototype.initialize = function () {
-        bw.init();
-    };
-    new BGWorker().initialize();
-})();
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "ccc-copyCode" && tab?.id) {
+    chrome.tabs.sendMessage(tab.id, { action: "copy-code" });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,9 @@
     "48": "images/curly-brackets-64.png",
     "128": "images/curly-brackets-128.png"
   },
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "matches": [ "<all_urls>" ],
@@ -23,7 +26,8 @@
     "open_in_tab": true
   },
   "permissions": [
-    "storage"
+    "storage",
+    "contextMenus"
   ],
   "manifest_version": 3
 }


### PR DESCRIPTION
## Summary
- declare `background.js` as a service worker in the manifest
- streamline background logic to register context menu

## Testing
- `npx --yes web-ext lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68934771fc408327918535408e14ceb2