### PR TITLE
Ignore Alt+C shortcut in text fields

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,6 +121,10 @@
             let cobj = this;
             window.addEventListener('keydown', function (e) {
                 if (e.altKey && (e.key === 'c' || e.key === 'C')) {
+                    let activeElem = document.activeElement;
+                    if (activeElem && (activeElem.tagName === 'INPUT' || activeElem.tagName === 'TEXTAREA' || activeElem.isContentEditable)) {
+                        return;
+                    }
                     cobj.copyActive = !cobj.copyActive;
                     cobj.saveState();
                     cobj.showMsg(cobj.copyActive ? 'Copying enabled' : 'Copying disabled');


### PR DESCRIPTION
## Summary
- Ignore Alt+C copy toggle when focus is on input, textarea, or contentEditable element

## Testing
- `node <<'NODE'
const cobj = {
  copyActive: true,
  saveState: () => console.log('saveState called'),
  showMsg: (msg) => { logs.push(msg); },
  registerShortcut: function() {
    let cobj = this;
    window.addEventListener('keydown', function(e) {
      if (e.altKey && (e.key === 'c' || e.key === 'C')) {
        let activeElem = document.activeElement;
        if (activeElem && (activeElem.tagName === 'INPUT' || activeElem.tagName === 'TEXTAREA' || activeElem.isContentEditable)) {
          return;
        }
        cobj.copyActive = !cobj.copyActive;
        cobj.saveState();
        cobj.showMsg(cobj.copyActive ? 'Copying enabled' : 'Copying disabled');
      }
    });
  }
};

const listeners = {};
global.window = {
  addEventListener: (type, cb) => { listeners[type] = cb; }
};
global.document = {
  activeElement: { tagName: 'BODY', isContentEditable: false }
};

const logs = [];

cobj.registerShortcut();

document.activeElement = { tagName: 'INPUT', isContentEditable: false };
listeners['keydown']({ altKey: true, key: 'c' });
console.log('after input:', { copyActive: cobj.copyActive, logs: logs.slice() });
logs.length = 0;

document.activeElement = { tagName: 'BODY', isContentEditable: false };
listeners['keydown']({ altKey: true, key: 'c' });
console.log('after body:', { copyActive: cobj.copyActive, logs: logs.slice() });
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689349569dd08327bab3e87b593272dc