### PR TITLE
refactor: centralize theme utilities

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     {
       "matches": [ "<all_urls>" ],
       "css": [ "style.css" ],
-      "js": [ "script.js" ],
+      "js": [ { "file": "script.js", "type": "module" } ],
       "run_at": "document_end"
     }
   ],

--- a/options.html
+++ b/options.html
@@ -38,6 +38,6 @@
         </div>
     </form>
     <div id="status"></div>
-    <script src="options.js"></script>
+    <script type="module" src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -1,4 +1,6 @@
 // Options page logic wrapped in an object to manage state and behaviour
+import { applyPreview } from './themeUtils.js';
+
 (function () {
     const optionsManager = {
         modeSelect: null,
@@ -34,19 +36,6 @@
 
             this.load();
         },
-        applyPreview: function (theme) {
-            if (!this.toastPreview) return;
-            if (theme.scheme === 'light') {
-                this.toastPreview.style.backgroundColor = '#f5f5f5';
-                this.toastPreview.style.color = '#000';
-            } else if (theme.scheme === 'custom') {
-                this.toastPreview.style.backgroundColor = theme.bgColor || '#6002ee';
-                this.toastPreview.style.color = theme.textColor || '#f5f5f5';
-            } else {
-                this.toastPreview.style.backgroundColor = '#6002ee';
-                this.toastPreview.style.color = '#f5f5f5';
-            }
-        },
         setThemeValues: function (theme) {
             const radio = document.querySelector(`input[name="scheme"][value="${theme.scheme}"]`);
             if (radio) {
@@ -59,7 +48,7 @@
             } else {
                 this.customColors.style.display = 'none';
             }
-            this.applyPreview(theme);
+            applyPreview(this.toastPreview, theme);
         },
         load: function () {
             if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
@@ -117,7 +106,7 @@
                 theme.bgColor = this.bgColor.value;
                 theme.textColor = this.textColor.value;
             }
-            this.applyPreview(theme);
+            applyPreview(this.toastPreview, theme);
         }
     };
 

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import { applyTheme } from './themeUtils.js';
+
 (function () {
     "use strict";
     let ccc = {
@@ -16,7 +18,7 @@
             let div = document.createElement('div');
             div.setAttribute("id", "cccToast");
             document.body.appendChild(div);
-            this.applyTheme();
+            applyTheme(div, this.theme);
         },
         copyCode: function () {
             let cobj = this;
@@ -171,24 +173,9 @@
                 localStorage.setItem('theme', JSON.stringify(this.theme));
             }
         },
-        applyTheme: function(){
-            const x = document.getElementById('cccToast');
-            if(!x) return;
-            const t = this.theme || {};
-            if(t.scheme === 'light'){
-                x.style.backgroundColor = '#f5f5f5';
-                x.style.color = '#000';
-            } else if(t.scheme === 'custom'){
-                x.style.backgroundColor = t.bgColor || '#6002ee';
-                x.style.color = t.textColor || '#f5f5f5';
-            } else {
-                x.style.backgroundColor = '#6002ee';
-                x.style.color = '#f5f5f5';
-            }
-        },
         showMsg: function (message) {
             let x = document.getElementById("cccToast");
-            this.applyTheme();
+            applyTheme(x, this.theme);
             x.className = "show";
             x.textContent = message;
             setTimeout(function () { x.className = x.className.replace("show", ""); }, 3000);

--- a/themeUtils.js
+++ b/themeUtils.js
@@ -1,0 +1,17 @@
+export function applyTheme(element, theme = {}) {
+    if (!element) return;
+    if (theme.scheme === 'light') {
+        element.style.backgroundColor = '#f5f5f5';
+        element.style.color = '#000';
+    } else if (theme.scheme === 'custom') {
+        element.style.backgroundColor = theme.bgColor || '#6002ee';
+        element.style.color = theme.textColor || '#f5f5f5';
+    } else {
+        element.style.backgroundColor = '#6002ee';
+        element.style.color = '#f5f5f5';
+    }
+}
+
+export function applyPreview(element, theme) {
+    applyTheme(element, theme);
+}


### PR DESCRIPTION
## Summary
- extract shared theme logic into `themeUtils.js`
- consume centralized `applyTheme` and `applyPreview` in content and options scripts
- load scripts as ES modules for reuse

## Testing
- `node --experimental-vm-modules <<'NODE'
const fs=require('fs');const vm=require('vm');const path=require('path');
const code=fs.readFileSync('themeUtils.js','utf8');
const mod=new vm.SourceTextModule(code,{url:'file://'+path.resolve('themeUtils.js')});
(async()=>{await mod.link(()=>{});await mod.evaluate();const{applyTheme,applyPreview}=mod.namespace;const el={style:{}};applyTheme(el,{scheme:'light'});console.log('light:',el.style.backgroundColor,el.style.color);const prev={style:{}};applyPreview(prev,{scheme:'custom',bgColor:'#111',textColor:'#eee'});console.log('custom:',prev.style.backgroundColor,prev.style.color);})();
NODE`
- `node --experimental-vm-modules <<'NODE'
const fs=require('fs');const vm=require('vm');const path=require('path');
const code=fs.readFileSync('themeUtils.js','utf8');
const mod=new vm.SourceTextModule(code,{url:'file://'+path.resolve('themeUtils.js')});
(async()=>{await mod.link(()=>{});await mod.evaluate();const{applyTheme}=mod.namespace;const el={style:{}};applyTheme(el,{scheme:'dark'});console.log('dark:',el.style.backgroundColor,el.style.color);})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68934b080c5c8327aa4c87d6210a0d5e