### PR TITLE
Remove copy buttons when copying disabled

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,9 @@ import { applyTheme } from './themeUtils.js';
                 delete target.dataset.cccPrevPos;
             }
         },
+        removeAllCopyButtons: function () {
+            document.querySelectorAll('.ccc-copy-btn').forEach(btn => btn.remove());
+        },
         copyFromElement: function (target) {
             if (!this.copyActive) {
                 return;
@@ -128,6 +131,9 @@ import { applyTheme } from './themeUtils.js';
                         return;
                     }
                     cobj.copyActive = !cobj.copyActive;
+                    if (!cobj.copyActive) {
+                        cobj.removeAllCopyButtons();
+                    }
                     cobj.saveState();
                     cobj.showMsg(cobj.copyActive ? 'Copying enabled' : 'Copying disabled');
                 }


### PR DESCRIPTION
## Summary
- add helper to remove all copy buttons
- clean up existing copy buttons when disabling copy feature

## Testing
- `node - <<'NODE'
const buttons=[{removed:false,remove(){this.removed=true;}},{removed:false,remove(){this.removed=true;}}];
const document={activeElement:{tagName:'BODY'},querySelectorAll(){return buttons;}};
const window={_listeners:{},addEventListener(t,f){(this._listeners[t]||(this._listeners[t]=[])).push(f);},dispatchEvent(e){(this._listeners[e.type]||[]).forEach(fn=>fn(e));}};
global.document=document;global.window=window;
const ccc={
 copyActive:true,
 removeAllCopyButtons:function(){document.querySelectorAll('.ccc-copy-btn').forEach(btn=>btn.remove());},
 registerShortcut:function(){let cobj=this;window.addEventListener('keydown',function(e){if(e.altKey&&(e.key==='c'||e.key==='C')){let activeElem=document.activeElement;if(activeElem&&(activeElem.tagName==='INPUT'||activeElem.tagName==='TEXTAREA'||activeElem.isContentEditable)){return;}cobj.copyActive=!cobj.copyActive;if(!cobj.copyActive){cobj.removeAllCopyButtons();}}});}
};
ccc.registerShortcut();
console.log('before', buttons.map(b=>b.removed));
window.dispatchEvent({type:'keydown', altKey:true, key:'c'});
console.log('after', buttons.map(b=>b.removed));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68934c89da0c8327a56e1ea64e64c766